### PR TITLE
fix: lodash security vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
         with:
           node-version: ${{ env.node_version }}
       - run: npm install
-      - run: npm run coverage
-      - uses: codecov/codecov-action@v3
+      - run: npm run test:coverage
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          slug: byu-oit/env-ssm
 
   lint:
     name: Lint Module

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/env-ssm",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Gets params from your environment first, then from the ssm parameter store.",
   "contributors": [
     "Gary Crye <gary_crye@byu.edu>",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
   "homepage": "https://github.com/byu-oit/env-ssm#readme",
   "dependencies": {
     "debug": "^4.3.1",
-    "lodash.chunk": "^4.2.0",
-    "lodash.merge": "^4.6.2",
-    "lodash.set": "^4.3.2"
+    "lodash": "^4.17.16"
   },
   "devDependencies": {
     "@aws-sdk/client-ssm": "^3.9.0",
@@ -41,9 +39,7 @@
     "@tsconfig/node18": "^1.0.1",
     "@types/debug": "^4.1.5",
     "@types/jest": "^29.2.4",
-    "@types/lodash.chunk": "^4.2.6",
-    "@types/lodash.merge": "^4.6.6",
-    "@types/lodash.set": "^4.3.6",
+    "@types/lodash": "^4.17.16",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",

--- a/src/env-ssm.ts
+++ b/src/env-ssm.ts
@@ -1,6 +1,6 @@
 import { SSMClient } from '@aws-sdk/client-ssm'
 import { from, IEnv, IOptionalVariable } from 'env-var'
-import merge from 'lodash.merge'
+import { merge } from 'lodash'
 import {
   loadDotEnv,
   loadProcessEnv,

--- a/src/loaders/ssm.ts
+++ b/src/loaders/ssm.ts
@@ -1,5 +1,4 @@
-import set from 'lodash.set'
-import chunk from 'lodash.chunk'
+import { set, chunk } from 'lodash'
 import {
   DescribeParametersCommand,
   GetParametersByPathCommand,


### PR DESCRIPTION
Pulling in individual lodash functions as packages introduces old vulnerabilities. To counteract this, we imported lodash as a whole.